### PR TITLE
Optional supplemental groups; updated version

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -10,16 +10,18 @@
 # @param user_home Home directory for the agent user and executables.
 # @param user_shell Shell for the agent user. Defaults to false on Linux and
 #   macOS to prevent logins as the agent user.
+# @param user_groups [Optional[Array[String]] Supplemental groups for the agent (ex: docker). Default value: undef
 # @param user_password Password for the agent user. This must be set on Windows.
 # @param endpoint The URL or IP address and port for the agent service.
 # @param environments Pipelines environments that have access to this agent.
 class pipelines::agent (
   Sensitive[String[1]]           $access_token,
   Sensitive[String[1]]           $secret_key,
-  String[1]                      $version        = '3.66.33',
+  String[1]                      $version        = '3.66.45',
   Boolean                        $manage_sudoers = true,
   String[1]                      $user_home      = $pipelines::agent::params::user_home,
   Optional[String[1]]            $user_shell     = $pipelines::agent::params::user_shell,
+  Optional[Array[String]]        $user_groups    = undef,
   Optional[Sensitive[String[1]]] $user_password  = undef,
   Optional[String[1]]            $endpoint       = undef,
   Optional[Array[String[1]]]     $environments   = undef,

--- a/manifests/agent/unix.pp
+++ b/manifests/agent/unix.pp
@@ -16,6 +16,7 @@ class pipelines::agent::unix {
     comment  => 'Puppet Pipelines User',
     home     => $user_home,
     shell    => $pipelines::agent::user_shell,
+    groups   => $::distelli::agent::user_groups,
     password => $pipelines::agent::user_password,
     system   => true,
   }

--- a/manifests/agent/windows.pp
+++ b/manifests/agent/windows.pp
@@ -17,11 +17,18 @@ class pipelines::agent::windows (
     $url = "https://s3.amazonaws.com/download.distelli.com/distelli.Windows-x86/${archive}"
   }
 
+  if $::distelli::agent::user_groups {
+    $user_groups = ['Users','Administrators'] + $::distelli::agent::user_groups
+  }
+  else {
+    $user_groups = ['Users','Administrators']
+  }
+
   user { 'distelli':
     ensure     => present,
     comment    => 'Puppet Pipelines User',
     home       => $pipelines::agent::user_home,
-    groups     => ['Users', 'Administrators'],
+    groups     => $user_groups,
     password   => $pipelines::agent::user_password,
     managehome => true,
   }


### PR DESCRIPTION
This makes it so the user can specify addtional groups for the agent.
The primary use case for this is adding the agent to the docker group.

This also updates the default version on nix and darwin from 3.66.33
to 3.66.45.